### PR TITLE
Player scores do not update with a new setup

### DIFF
--- a/src/main/java/net/porillo/listeners/CO2Listener.java
+++ b/src/main/java/net/porillo/listeners/CO2Listener.java
@@ -59,7 +59,7 @@ public class CO2Listener implements Listener {
 		if (furnaceTable.getLocationMap().containsKey(location)) {
 			furnace = furnaceTable.getFurnaceMap().get(furnaceTable.getLocationMap().get(location));
 			UUID uuid = playerTable.getUuidMap().get(furnace.getOwnerID());
-			polluter = playerTable.getOrCreatePlayer(uuid, false);
+			polluter = playerTable.getPlayers().get(uuid);
 		} else {
 			/*
 			 * This might happen if a player has a redstone hopper setup that feeds untracked furnaces
@@ -88,16 +88,20 @@ public class CO2Listener implements Listener {
 		Contribution contrib = worldClimateEngine.furnaceBurn(furnace, event.getFuel());
 
 		// increment polluters carbon score
-		int carbonScore = polluter.getCarbonScore();
-		polluter.setCarbonScore(carbonScore + contrib.getContributionValue());
+		if (polluter != null) {
+			int carbonScore = polluter.getCarbonScore();
+			polluter.setCarbonScore(carbonScore + contrib.getContributionValue());
+		}
 
 		// increment worlds carbon score
 		int carbon = world.getCarbonValue();
 		world.setCarbonValue(carbon + contrib.getContributionValue());
 
 		// Queue an update to the player table
-		PlayerUpdateQuery updateQuery = new PlayerUpdateQuery(polluter);
-		AsyncDBQueue.getInstance().queueUpdateQuery(updateQuery);
+		if (polluter != null) {
+			PlayerUpdateQuery updateQuery = new PlayerUpdateQuery(polluter);
+			AsyncDBQueue.getInstance().queueUpdateQuery(updateQuery);
+		}
 
 		// Queue an insert into the contributions table
 		ContributionInsertQuery insertQuery = new ContributionInsertQuery(contrib);

--- a/src/main/java/net/porillo/objects/Furnace.java
+++ b/src/main/java/net/porillo/objects/Furnace.java
@@ -45,7 +45,7 @@ public class Furnace {
 
 	public GPlayer getOwner() {
 		PlayerTable playerTable = GlobalWarming.getInstance().getTableManager().getPlayerTable();
-		UUID ownerUUID = playerTable.getUuidMap().get(uniqueID);
+		UUID ownerUUID = playerTable.getUuidMap().get(ownerID);
 		return playerTable.getPlayers().get(ownerUUID);
 	}
 

--- a/src/main/java/net/porillo/objects/Tree.java
+++ b/src/main/java/net/porillo/objects/Tree.java
@@ -35,7 +35,7 @@ public class Tree {
 
 	public GPlayer getOwner() {
 		PlayerTable playerTable = GlobalWarming.getInstance().getTableManager().getPlayerTable();
-		UUID ownerUUID = playerTable.getUuidMap().get(uniqueID);
+		UUID ownerUUID = playerTable.getUuidMap().get(ownerID);
 		return playerTable.getPlayers().get(ownerUUID);
 	}
 


### PR DESCRIPTION
The furnace and tree classes are using the wrong ID for player lookups.  This can be reproduced with a new database (no initial records): join the server, create a new furnace and smelt something.  The global score will update, but the player's score will not.